### PR TITLE
Improve backend deployment

### DIFF
--- a/.github/workflows/backend-deploy.yml
+++ b/.github/workflows/backend-deploy.yml
@@ -1,8 +1,9 @@
-name: Deploy code to EC2 instance
+name: Deploy backend to EC2 instance
 
 on:
   push:
     branches: [ main ]
+    paths: [ 'backend/**' ]
 
 jobs:
   deploy:

--- a/.github/workflows/backend-deploy.yml
+++ b/.github/workflows/backend-deploy.yml
@@ -4,13 +4,14 @@ on:
   push:
     branches: [ main ]
     paths: [ 'backend/**' ]
+  workflow_dispatch:
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
       - name: Rebuild backend and deploy
-        uses: appleboy/ssh-action@master
+        uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2  # v1.2.5, pinned for supply chain safety; get the new full SHA if we need to updgrade
         with:
           host: ${{ secrets.EC2_URL }}
           username: 'ubuntu'


### PR DESCRIPTION
- Only run the backend deployment when the backend itself changes!
- Give the option for manual triggering of backend deploy with `workflow_dispatch`
- SHA-pin the SSH action for supply-chain safety