### PR TITLE
More improvements to backend deploy action

### DIFF
--- a/.github/workflows/backend-deploy.yml
+++ b/.github/workflows/backend-deploy.yml
@@ -16,6 +16,7 @@ jobs:
           host: ${{ secrets.EC2_URL }}
           username: 'ubuntu'
           key: ${{ secrets.SSH_PRIVATE_KEY }}
+          capture_stdout: true
           script: |
             set -e
 

--- a/.github/workflows/backend-deploy.yml
+++ b/.github/workflows/backend-deploy.yml
@@ -11,12 +11,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Rebuild backend and deploy
+        id: deploy
         uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2  # v1.2.5, pinned for supply chain safety; get the new full SHA if we need to upgrade
         with:
           host: ${{ secrets.EC2_URL }}
           username: 'ubuntu'
           key: ${{ secrets.SSH_PRIVATE_KEY }}
           capture_stdout: true
+          debug: true
           script: |
             set -e
 
@@ -48,3 +50,7 @@ jobs:
 
             echo "=== Saving PM2 ==="
             pm2 save
+
+      - name: Show deploy output
+        if: always()
+        run: echo "${{ steps.deploy.outputs.stdout }}"

--- a/.github/workflows/backend-deploy.yml
+++ b/.github/workflows/backend-deploy.yml
@@ -23,8 +23,8 @@ jobs:
             set -e
 
             echo "=== Setting up Node ==="
-            export NVM_DIR=~/.nvm
-            source ~/.nvm/nvm.sh
+            export NVM_DIR="$HOME/.nvm"
+            . "$NVM_DIR/nvm.sh"
 
             echo "=== Installing Node ==="
             nvm install 20

--- a/.github/workflows/backend-deploy.yml
+++ b/.github/workflows/backend-deploy.yml
@@ -11,14 +11,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Rebuild backend and deploy
-        id: deploy
         uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2  # v1.2.5, pinned for supply chain safety; get the new full SHA if we need to upgrade
         with:
           host: ${{ secrets.EC2_URL }}
           username: 'ubuntu'
           key: ${{ secrets.SSH_PRIVATE_KEY }}
-          capture_stdout: true
-          debug: true
           script: |
             echo "=== Setting up Node ==="
             export NVM_DIR="$HOME/.nvm"
@@ -50,7 +47,3 @@ jobs:
 
             echo "=== Saving PM2 ==="
             pm2 save
-
-      - name: Show deploy output
-        if: always()
-        run: echo "${{ steps.deploy.outputs.stdout }}"

--- a/.github/workflows/backend-deploy.yml
+++ b/.github/workflows/backend-deploy.yml
@@ -19,20 +19,31 @@ jobs:
           script: |
             set -e
 
+            echo "=== Setting up Node ==="
             export NVM_DIR=~/.nvm
             source ~/.nvm/nvm.sh
 
+            echo "=== Installing Node ==="
             nvm install 20
             nvm use 20
+
+            echo "=== Installing PM2 and Yarn ==="
             npm i -g pm2 yarn
 
+            echo "=== Pulling latest code ==="
             cd /home/ubuntu/DishZero
             git pull
 
+            echo "=== Installing dependencies ==="
             cd backend
             yarn install --frozen-lockfile
             yarn cache clean
+
+            echo "=== Building ==="
             yarn build
 
+            echo "=== Restarting server ==="
             pm2 restart dishzero || pm2 start yarn --name dishzero -- start
+
+            echo "=== Saving PM2 ==="
             pm2 save

--- a/.github/workflows/backend-deploy.yml
+++ b/.github/workflows/backend-deploy.yml
@@ -11,20 +11,27 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Rebuild backend and deploy
-        uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2  # v1.2.5, pinned for supply chain safety; get the new full SHA if we need to updgrade
+        uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2  # v1.2.5, pinned for supply chain safety; get the new full SHA if we need to upgrade
         with:
           host: ${{ secrets.EC2_URL }}
           username: 'ubuntu'
           key: ${{ secrets.SSH_PRIVATE_KEY }}
           script: |
-            cd /home/ubuntu/DishZero/backend
+            set -e
+
             export NVM_DIR=~/.nvm
             source ~/.nvm/nvm.sh
-            npm i -g pm2
-            npm i -g yarn
-            pm2 stop dishzero
-            pm2 delete dishzero
+
+            nvm install 20
+            npm i -g pm2 yarn
+
+            cd /home/ubuntu/DishZero
             git pull
-            yarn install
+
+            cd backend
+            yarn install --frozen-lockfile
+            yarn cache clean
             yarn build
-            pm2 start yarn --name "dishzero" -- start
+
+            pm2 restart dishzero || pm2 start yarn --name dishzero -- start
+            pm2 save

--- a/.github/workflows/backend-deploy.yml
+++ b/.github/workflows/backend-deploy.yml
@@ -20,11 +20,11 @@ jobs:
           capture_stdout: true
           debug: true
           script: |
-            set -e
-
             echo "=== Setting up Node ==="
             export NVM_DIR="$HOME/.nvm"
             . "$NVM_DIR/nvm.sh"
+
+            set -e
 
             echo "=== Installing Node ==="
             nvm install 20

--- a/.github/workflows/backend-deploy.yml
+++ b/.github/workflows/backend-deploy.yml
@@ -19,8 +19,8 @@ jobs:
           script: |
             set -e
 
-            export NVM_DIR=~/.nvm
-            source ~/.nvm/nvm.sh
+            export NVM_DIR="$HOME/.nvm"
+            [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
 
             nvm install 20
             npm i -g pm2 yarn

--- a/.github/workflows/backend-deploy.yml
+++ b/.github/workflows/backend-deploy.yml
@@ -19,10 +19,11 @@ jobs:
           script: |
             set -e
 
-            export NVM_DIR="$HOME/.nvm"
-            [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
+            export NVM_DIR=~/.nvm
+            source ~/.nvm/nvm.sh
 
             nvm install 20
+            nvm use 20
             npm i -g pm2 yarn
 
             cd /home/ubuntu/DishZero


### PR DESCRIPTION
- Fail the whole action on any command
- Use Node 20
- Install with frozen lockfile (best practice)
- Keep the yarn cache cleaned to keep more storage free
- Use `pm2 restart` instead of a `delete`/`start`. This is better because:
    - no downtime while are we rebuilding the app
    - we only restart the app once the deploy has succeeded